### PR TITLE
fix: Add more rendering hooks to render diagrams at all times.

### DIFF
--- a/dbt_diagrams/resources/mermaid_snippet.html
+++ b/dbt_diagrams/resources/mermaid_snippet.html
@@ -12,16 +12,16 @@
     // For some unknown reason, the Prism complete hook doesn't trigger
     // when first entering the dbt docs side. This is why we subscribe to
     // the only hook that does trigger on page load.
-    Prism.hooks.add("before-highlightall", () => {setTimeout(renderMermaid, 200)})
-
-    // Setup additional render as backup to the previous Prism hook
-    window.addEventListener("load", () => {
-        setTimeout(renderMermaid, 250)
-    });
+    Prism.hooks.add("before-highlightall", () => setTimeout(renderMermaid, 200))
 
     // This one is triggered on all subsequent Prism renders. It works for
-    // all except initial page load. As an alternative to this, we could
-    // subscribe to the `popstate` browser event. This Prism hook is safer
-    // because it is guaranteed to run after the Prism highlight.
+    // all except initial page load and back navigation. Those are covered
+    // by load and popstate events hooks.
     Prism.hooks.add("complete", renderMermaid)
+
+    // Setup additional render as backup to the previous Prism hook
+    window.addEventListener("load", () => setTimeout(renderMermaid, 100));
+
+
+    window.addEventListener("popstate", () => setTimeout(renderMermaid, 0));
 </script>


### PR DESCRIPTION
Before, navigating back and forth would leave some diagrams unrendered.