### PR TITLE
Python 3.12 support

### DIFF
--- a/.git_archival.json
+++ b/.git_archival.json
@@ -1,0 +1,7 @@
+{
+  "hash-full": "$Format:%H$",
+  "hash-short": "$Format:%h$",
+  "timestamp": "$Format:%cI$",
+  "refs": "$Format:%D$",
+  "describe": "$Format:%(describe:tags=true,match=v[0-9]*)$"
+}

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.json  export-subst

--- a/dbt_diagrams/domain.py
+++ b/dbt_diagrams/domain.py
@@ -4,7 +4,11 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field, Extra
 
-PYDANTIC_MODEL_CONFIG = {"extra": Extra.forbid, "allow_mutation": False}
+
+class DomainBaseModel(BaseModel):
+    class Config:
+        extra = Extra.forbid
+        frozen = True
 
 
 class Cardinality(Enum):
@@ -30,7 +34,8 @@ class Cardinality(Enum):
         }[self]
 
 
-class MetaERDConnection(BaseModel, **PYDANTIC_MODEL_CONFIG):
+class MetaERDConnection(DomainBaseModel):
+
     target: str
     source_cardinality: Cardinality
     target_cardinality: Cardinality
@@ -38,11 +43,11 @@ class MetaERDConnection(BaseModel, **PYDANTIC_MODEL_CONFIG):
     label: Optional[str] = None
 
 
-class MetaERDSection(BaseModel, **PYDANTIC_MODEL_CONFIG):
+class MetaERDSection(DomainBaseModel):
     connections: List[MetaERDConnection] = Field(default_factory=list)
 
 
-class Column(BaseModel, **PYDANTIC_MODEL_CONFIG):
+class Column(DomainBaseModel):
     name: str
     type: Optional[str]
 
@@ -92,12 +97,15 @@ class Column(BaseModel, **PYDANTIC_MODEL_CONFIG):
         return cls(name=col_name, type=col_type)  # type: ignore [arg-type]
 
 
-class Table(BaseModel, **PYDANTIC_MODEL_CONFIG):
+class Table(DomainBaseModel):
     model_name: str
     rendered_name: str
     target_database: str
     target_schema: str
     columns: List[Column]
+    
+    class Config(DomainBaseModel.Config):
+        protected_namespaces = ()
 
     def as_mermaid_table(self, include_cols=False) -> str:
         if include_cols:
@@ -134,7 +142,7 @@ class Table(BaseModel, **PYDANTIC_MODEL_CONFIG):
         )
 
 
-class Relation(BaseModel, **PYDANTIC_MODEL_CONFIG):
+class Relation(DomainBaseModel):
     diagram: str
     source: Table
     target: Table

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,10 @@ include = ["resources/**"]
 dbt-diagrams = "dbt_diagrams.cli:cli"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.12"
-click = "8.1.3"
+python = ">=3.8"
+click = ">=8.1.3"
 pyyaml = ">=6.0"
-pydantic = "1.10.13"
+pydantic = ">=2.0"
 
 playwright = { version = "1.40.0", optional = true }
 fastapi = { version = "0.105.0", optional = true }


### PR DESCRIPTION
This PR adds support for python 3.12 and updates pydantic to V2. Also made it possible to install the package from a zip file via pip