### PR TITLE
Retain source columns order, but sort tables and relations alphabetically

### DIFF
--- a/dbt_diagrams/cli.py
+++ b/dbt_diagrams/cli.py
@@ -89,6 +89,9 @@ async def render_erds(ctx, dbt_target_dir, manifest, catalog, format, output_dir
     with the right metadata. Check the code repository README for further instructions
     on metadata config.
     """
+    if str(output_dir) == ".":
+        output_dir = Path.cwd()
+
     if dbt_target_dir and (manifest or catalog):
         exit_with_error("Either define target dir or manifest but not both.")
     elif not dbt_target_dir and not (manifest or catalog):
@@ -124,7 +127,7 @@ async def render_erds(ctx, dbt_target_dir, manifest, catalog, format, output_dir
     else:
         write_as_mmd(diagrams, output_dir)
 
-    click.secho(f"Finished. Output written to {output_dir.cwd()}.", fg="green")
+    click.secho(f"Finished. Output written to {output_dir}", fg="green")
 
 
 # Disable REST API for now because of multi-ERD support that needs to be built-in.

--- a/dbt_diagrams/domain.py
+++ b/dbt_diagrams/domain.py
@@ -112,25 +112,28 @@ class Table(BaseModel, **PYDANTIC_MODEL_CONFIG):
     ) -> "Table":
         catalog_node_cols = catalog_node.get("columns", {}) if catalog_node else {}
         manifest_node_cols = manifest_node.get("columns", {})
+
+        catalog_cols_ids = list(catalog_node_cols.keys())
+        # Detecting any additional columns listed in manifest but not in catalog, sorting them alphabetically
+        manifest_cols_ids = list(set(manifest_node_cols.keys()) - set(catalog_cols_ids))
+        manifest_cols_ids.sort()
+        all_col_ids = catalog_cols_ids + manifest_cols_ids
+
         # TODO: log undocumented cols
         # missing_manifest_col_ids = set(catalog_node_cols.keys()) - set(manifest_node_cols.keys())
-        all_col_ids = set(catalog_node_cols.keys()) | set(manifest_node_cols.keys())
 
         return cls(
             model_name=manifest_node["name"],
             rendered_name=manifest_node["alias"],
             target_database=manifest_node["database"],
             target_schema=manifest_node["schema"],
-            # Sort columns alphabetically
-            columns=sorted(
+            columns=
                 [
                     Column.from_manifest_catalog_node_columns(
                         manifest_node_cols.get(col_id), catalog_node_cols.get(col_id)
                     )
                     for col_id in all_col_ids
-                ],
-                key=lambda x: x.name,
-            ),
+                ]
         )
 
 

--- a/dbt_diagrams/mermaid.py
+++ b/dbt_diagrams/mermaid.py
@@ -27,13 +27,23 @@ def _mermaid_erd_from_relations(relations: List[Relation], include_cols: bool = 
     mentioned_tables = {
         t.model_name: t for t in itertools.chain(*([r.source, r.target] for r in relations))
     }
+    tables = list(mentioned_tables.values())
+
+    def getTableName(t):
+        return t.as_mermaid_table(include_cols)
+    tables.sort(reverse=False, key=getTableName)
+
     tables_section = "\n".join(
-        (f"\t{t.as_mermaid_table(include_cols)}\n" for t in mentioned_tables.values())
+        (f"\t{getTableName(t)}\n" for t in tables)
     )
+
+    def getRelationName(rel):
+        return rel.as_mermaid_relation()
+    relations.sort(reverse=False, key=getRelationName)
 
     relation_section = ""
     for rel in relations:
-        relation_section += f"\t{rel.as_mermaid_relation()}\n"
+        relation_section += f"\t{getRelationName(rel)}\n"
 
     return f"erDiagram\n{relation_section}\n{tables_section}"
 
@@ -52,6 +62,7 @@ def mermaid_erds_from_manifest_and_catalog(
             for node_id, node in manifest["nodes"].items()
         )
     }
+
     relations = list(
         itertools.chain(
             *(Relation.from_manifest_node(n, tables) for n in manifest["nodes"].values())


### PR DESCRIPTION
Changes:
- Fix alphabetical sorting of columns, retain source columns order
- Fix 'str' object has no attribute 'cwd' when specifying output path
- Add alphabetical sorting of tables and relations to avoid unnecessary changes due to their random ordering