### PR TITLE
Moving to Poetry 2

### DIFF
--- a/.github/workflows/check_test.yml
+++ b/.github/workflows/check_test.yml
@@ -26,8 +26,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install Poetry
-        run: make poetry
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
 
       - name: Setup Python
         uses: actions/setup-python@v4
@@ -49,8 +49,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install Poetry
-        run: make poetry
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,8 +14,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install Poetry
-        run: make poetry
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/.github/workflows/publish_gh_page.yml
+++ b/.github/workflows/publish_gh_page.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v3
 
-      - name: Install Poetry
-        run: pip3 install poetry==1.6.1
+      - name: Install and configure Poetry
+        uses: snok/install-poetry@v1
 
       - name: Setup Python
         uses: actions/setup-python@v4

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ install:
 test:
 	poetry run pytest tests
 
-poetry:
-	pip3 install poetry==1.6.1
-	pip3 install "poetry-dynamic-versioning[plugin]"==1.2.0
-
 ruff:
 	poetry run ruff --fix .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,13 +35,16 @@ mypy = "^1.2.0"
 pytest = "^7.3.1"
 types-pyyaml = "^6.0.12.11"
 
+[tool.poetry.requires-plugins]
+poetry-dynamic-versioning = { version = ">=1.0.0,<2.0.0", extras = ["plugin"] }
+
 [tool.poetry-dynamic-versioning]
 enable = true
 vcs = "git"
 style = "semver"
 
 [build-system]
-requires = ["poetry-core>=1.5.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+requires = ["poetry-core>=1.5.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.ruff]


### PR DESCRIPTION
Poetry moved to [v2](https://github.com/python-poetry/poetry/releases/tag/2.0.0) in January. This PR:
* Updates how the `dynamic-versioning` plugin is installed to be compatible with Poetry v2.
* Updates the workflows to use a GitHub Action to install Poetry, ensuring we have a robust way of doing this.