### PR TITLE
Adding dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+    - package-ecosystem: github-actions
+      directory: /
+      schedule:
+          interval: weekly


### PR DESCRIPTION
A lot of the GitHub Actions used in this repo are outdated. This PR adds dependabot so we will get automated PRs when GitHub Actions we use have a major version increase.