### PR TITLE
Testing across multiple python versions

### DIFF
--- a/.github/workflows/check_test.yml
+++ b/.github/workflows/check_test.yml
@@ -42,8 +42,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: check
     permissions:
       contents: read
+    strategy:
+        fail-fast: false
+        matrix:
+            python-version:
+                - '3.8'
+                - '3.9'
+                - '3.10'
+                - '3.11'
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -55,6 +64,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           cache: poetry
+          python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: make install


### PR DESCRIPTION
Currently the CI pipeline runs tests using python 3.11 only. This PR ensures the tests run for all the supported versions of python.